### PR TITLE
chore: static site configurable prune

### DIFF
--- a/src/lib/aws/construct/static-site/main.ts
+++ b/src/lib/aws/construct/static-site/main.ts
@@ -192,6 +192,7 @@ export class StaticSite extends CommonConstruct {
    * @summary Method to deploy the static assets into s3 bucket for static site
    */
   protected deploySite() {
+    const prune = this.props.pruneOnDeployment ?? true
     this.s3Manager.doBucketDeployment(
       `${this.id}-deployment`,
       this,
@@ -199,7 +200,7 @@ export class StaticSite extends CommonConstruct {
       this.siteDistribution,
       [this.props.siteSource],
       '',
-      true
+      prune
     )
   }
 

--- a/src/lib/aws/construct/static-site/types.ts
+++ b/src/lib/aws/construct/static-site/types.ts
@@ -21,5 +21,11 @@ export interface StaticSiteProps extends CommonStackProps {
   siteSource: ISource
   siteSubDomain?: string
   timezone: string
+  /**
+   * Whether to prune the contents of the bucket when deploying assets.
+   *
+   * @default true
+   */
+  pruneOnDeployment?: boolean
   useExistingHostedZone: boolean
 }


### PR DESCRIPTION
Removes hardcoded value for `prune` and enables to configure behaviour of `prune` on deployment as part of construct properties.

Ensure backward compatibility by making `pruneOnDeployment` property optional and defaulting to `true` if not defined.