### PR TITLE
refactor: open init resources

### DIFF
--- a/src/lib/aws/construct/api-to-any-target/main.ts
+++ b/src/lib/aws/construct/api-to-any-target/main.ts
@@ -49,7 +49,7 @@ export class ApiToAnyTarget extends CommonConstruct {
     this.apiToAnyTargetRestApi = new ApiToAnyTargetRestApi()
   }
 
-  protected initResources() {
+  public initResources() {
     /* application related resources */
     this.resolveSecrets()
 

--- a/src/lib/aws/construct/api-to-eventbridge-target-with-sns/main.ts
+++ b/src/lib/aws/construct/api-to-eventbridge-target-with-sns/main.ts
@@ -80,7 +80,7 @@ export class ApiToEventBridgeTargetWithSns extends CommonConstruct {
     this.apiResource = 'notify'
   }
 
-  protected initResources() {
+  public initResources() {
     /* application related resources */
     this.resolveSecrets()
 

--- a/src/lib/aws/construct/api-to-eventbridge-target/main.ts
+++ b/src/lib/aws/construct/api-to-eventbridge-target/main.ts
@@ -71,7 +71,7 @@ export class ApiToEventBridgeTarget extends CommonConstruct {
     this.apiResource = 'notify'
   }
 
-  protected initResources() {
+  public initResources() {
     /* application related resources */
     this.resolveSecrets()
 

--- a/src/lib/aws/construct/api-to-lambda-target/main.ts
+++ b/src/lib/aws/construct/api-to-lambda-target/main.ts
@@ -36,7 +36,7 @@ export class ApiToLambdaTarget extends CommonConstruct {
     this.apiToLambdaTargetRestApi = new ApiToLambdaTargetRestApi()
   }
 
-  protected initResources() {
+  public initResources() {
     this.resolveSecrets()
     this.resolveHostedZone()
     this.resolveCertificate()

--- a/src/lib/aws/construct/application-configuration/main.ts
+++ b/src/lib/aws/construct/application-configuration/main.ts
@@ -26,7 +26,7 @@ export class ApplicationConfiguration extends CommonConstruct {
     this.id = id
   }
 
-  initResources() {
+  public initResources() {
     this.createConfiguration()
     this.resolveEnvironmentVariables()
   }

--- a/src/lib/aws/construct/event-handler/main.ts
+++ b/src/lib/aws/construct/event-handler/main.ts
@@ -41,7 +41,7 @@ export class EventHandler extends CommonConstruct {
     this.handler = new Handler()
   }
 
-  protected initResources() {
+  public initResources() {
     this.createSQSEventSource()
     this.createWorkflow()
     this.createEventRulePattern()

--- a/src/lib/aws/construct/piped-event-handler/main.ts
+++ b/src/lib/aws/construct/piped-event-handler/main.ts
@@ -33,7 +33,7 @@ export class PipedEventHandler extends EventHandler {
     this.provisionTarget = false
   }
 
-  protected initResources() {
+  public initResources() {
     this.createPipedQueue()
     this.handler.sqsTargets = [new SqsQueue(this.pipedQueue)]
     super.initResources()

--- a/src/lib/aws/construct/rest-api-lambda-with-cache/main.ts
+++ b/src/lib/aws/construct/rest-api-lambda-with-cache/main.ts
@@ -43,7 +43,7 @@ export abstract class RestApiLambdaWithCache extends RestApiLambda {
     this.id = id
   }
 
-  protected initResources() {
+  public initResources() {
     this.resolveVpc()
     this.resolveSecurityGroup()
     this.createElastiCache()

--- a/src/lib/aws/construct/rest-api-lambda/main.ts
+++ b/src/lib/aws/construct/rest-api-lambda/main.ts
@@ -54,7 +54,7 @@ export abstract class RestApiLambda extends CommonConstruct {
   /**
    * @summary Initialise and provision resources
    */
-  protected initResources() {
+  public initResources() {
     this.resolveSecrets()
     this.resolveHostedZone()
     this.resolveCertificate()

--- a/src/lib/aws/construct/site-with-ecs-backend/main.ts
+++ b/src/lib/aws/construct/site-with-ecs-backend/main.ts
@@ -97,7 +97,7 @@ export class SiteWithEcsBackend extends CommonConstruct {
   /**
    * @summary Initialise and provision resources
    */
-  protected initResources() {
+  public initResources() {
     this.resolveHostedZone()
     this.resolveCertificate()
     this.resolveSiteSecrets()

--- a/src/lib/aws/construct/site-with-lambda-backend/main.ts
+++ b/src/lib/aws/construct/site-with-lambda-backend/main.ts
@@ -80,7 +80,7 @@ export class SiteWithLambdaBackend extends CommonConstruct {
   /**
    * @summary Initialise and provision resources
    */
-  protected initResources() {
+  public initResources() {
     this.resolveHostedZone()
     this.resolveCertificate()
     this.resolveSiteSecrets()

--- a/src/lib/aws/construct/static-site/main.ts
+++ b/src/lib/aws/construct/static-site/main.ts
@@ -55,7 +55,7 @@ export class StaticSite extends CommonConstruct {
   /**
    * @summary Initialise and provision resources
    */
-  protected initResources() {
+  public initResources() {
     this.resolveHostedZone()
     this.resolveCertificate()
     this.createSiteLogBucket()

--- a/src/test/aws/construct/event-handler.test.ts
+++ b/src/test/aws/construct/event-handler.test.ts
@@ -73,7 +73,7 @@ class TestEventHandler extends EventHandler {
     this.initResources()
   }
 
-  protected initResources() {
+  public initResources() {
     const testPolicy = new PolicyDocument({ statements: [this.iamManager.statementForReadSecrets(this)] })
     const testRole = this.iamManager.createRoleForEcsExecution('test-role', this, testPolicy)
     this.testLambda = this.lambdaManager.createLambdaFunction(

--- a/src/test/aws/construct/piped-event-handler.test.ts
+++ b/src/test/aws/construct/piped-event-handler.test.ts
@@ -75,7 +75,7 @@ class TestPipedEventHandler extends PipedEventHandler {
     this.initResources()
   }
 
-  protected initResources() {
+  public initResources() {
     const testPolicy = new PolicyDocument({ statements: [this.iamManager.statementForReadSecrets(this)] })
     const testRole = this.iamManager.createRoleForEcsExecution('test-role', this, testPolicy)
     this.testLambda = this.lambdaManager.createLambdaFunction(


### PR DESCRIPTION
Makes `initResources` public to allow construct to be created without inheritance.

BREAKING CHANGE: Changing `initResource` from protected to public scope.