### PR TITLE
feat: add support for deep merging config

### DIFF
--- a/.changeset/young-hairs-follow.md
+++ b/.changeset/young-hairs-follow.md
@@ -1,0 +1,8 @@
+---
+'@gradientedge/cdk-utils-cloudflare': minor
+'@gradientedge/cdk-utils-azure': minor
+'@gradientedge/cdk-utils-aws': minor
+'@gradientedge/cdk-utils': minor
+---
+
+feat: add support for deep merging config

--- a/packages/aws/src/common/stack.ts
+++ b/packages/aws/src/common/stack.ts
@@ -116,7 +116,11 @@ export class CommonStack extends Stack {
 
       /* set each of the property into the cdk node context */
       _.keys(extraContextProps).forEach((propKey: any) => {
-        this.node.setContext(propKey, extraContextProps[propKey])
+        if (typeof extraContextProps[propKey] === 'object' && !Array.isArray(extraContextProps[propKey])) {
+          this.node.setContext(propKey, _.merge(this.node.tryGetContext(propKey), extraContextProps[propKey]))
+        } else {
+          this.node.setContext(propKey, extraContextProps[propKey])
+        }
       })
     })
   }
@@ -155,7 +159,11 @@ export class CommonStack extends Stack {
 
     /* set each of the property into the cdk node context */
     _.keys(regionContextProps).forEach((propKey: any) => {
-      this.node.setContext(propKey, regionContextProps[propKey])
+      if (typeof regionContextProps[propKey] === 'object' && !Array.isArray(regionContextProps[propKey])) {
+        this.node.setContext(propKey, _.merge(this.node.tryGetContext(propKey), regionContextProps[propKey]))
+      } else {
+        this.node.setContext(propKey, regionContextProps[propKey])
+      }
     })
   }
 
@@ -235,7 +243,11 @@ export class CommonStack extends Stack {
 
     /* set each of the property into the cdk node context */
     _.keys(stageRegionContextProps).forEach((propKey: any) => {
-      this.node.setContext(propKey, stageRegionContextProps[propKey])
+      if (typeof stageRegionContextProps[propKey] === 'object' && !Array.isArray(stageRegionContextProps[propKey])) {
+        this.node.setContext(propKey, _.merge(this.node.tryGetContext(propKey), stageRegionContextProps[propKey]))
+      } else {
+        this.node.setContext(propKey, stageRegionContextProps[propKey])
+      }
     })
   }
 

--- a/packages/aws/test/common/cdk-config/deep-merge-base.json
+++ b/packages/aws/test/common/cdk-config/deep-merge-base.json
@@ -1,0 +1,21 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "error",
+      "format": "json",
+      "destination": "stdout"
+    },
+    "cache": {
+      "enabled": true,
+      "ttl": 300,
+      "maxSize": 1000
+    },
+    "monitoring": {
+      "enabled": false,
+      "endpoint": "https://monitor.example.com"
+    }
+  },
+  "logLevel": "error",
+  "resourcePrefix": "ge",
+  "globalPrefix": "gradientedge"
+}

--- a/packages/aws/test/common/cdk-config/deep-merge-overlay.json
+++ b/packages/aws/test/common/cdk-config/deep-merge-overlay.json
@@ -1,0 +1,10 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "warn"
+    },
+    "monitoring": {
+      "enabled": true
+    }
+  }
+}

--- a/packages/aws/test/common/cdk-env-region/deep-merge-tst.deep-merge-eu-west-1.json
+++ b/packages/aws/test/common/cdk-env-region/deep-merge-tst.deep-merge-eu-west-1.json
@@ -1,0 +1,9 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "trace"
+    }
+  },
+  "logLevel": "trace",
+  "resourcePrefix": "ge-tst-eu-west-1"
+}

--- a/packages/aws/test/common/cdk-env/deep-merge-tst.json
+++ b/packages/aws/test/common/cdk-env/deep-merge-tst.json
@@ -1,0 +1,14 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "debug"
+    },
+    "cache": {
+      "maxSize": 2000
+    }
+  },
+  "logLevel": "debug",
+  "resourcePrefix": "ge-tst",
+  "subDomain": "tst",
+  "stage": "deep-merge-tst"
+}

--- a/packages/aws/test/common/cdk-region/deep-merge-eu-west-1.json
+++ b/packages/aws/test/common/cdk-region/deep-merge-eu-west-1.json
@@ -1,0 +1,14 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "info",
+      "destination": "cloudwatch"
+    },
+    "cache": {
+      "ttl": 600
+    },
+    "region": "eu-west-1"
+  },
+  "logLevel": "warn",
+  "resourcePrefix": "ge-eu-west-1"
+}

--- a/packages/aws/test/common/common-stack-deep-merge.test.ts
+++ b/packages/aws/test/common/common-stack-deep-merge.test.ts
@@ -1,0 +1,215 @@
+import * as cdk from 'aws-cdk-lib'
+import { CommonStack, CommonStackProps } from '../../src/index.js'
+
+interface TestStackProps extends CommonStackProps {
+  serverConfig?: any
+  logLevel?: string
+}
+
+describe('CommonStack - Deep Merge - Extra Contexts', () => {
+  const props = {
+    domainName: 'gradientedge.io',
+    extraContexts: [
+      'packages/aws/test/common/cdk-config/deep-merge-base.json',
+      'packages/aws/test/common/cdk-config/deep-merge-overlay.json',
+    ],
+    name: 'test-deep-merge-extra',
+    region: 'eu-west-1',
+    stackName: 'test-deep-merge-extra',
+    stage: 'test',
+    stageContextPath: 'packages/aws/test/common/cdk-env',
+  }
+
+  class TestStack extends CommonStack {
+    declare props: TestStackProps
+
+    constructor(parent: cdk.App, name: string, stackProps: any) {
+      super(parent, name, props)
+    }
+
+    protected determineConstructProps(stackProps: cdk.StackProps) {
+      return {
+        ...super.determineConstructProps(stackProps),
+        serverConfig: this.node.tryGetContext('serverConfig'),
+        logLevel: this.node.tryGetContext('logLevel'),
+      }
+    }
+  }
+
+  const app = new cdk.App({ context: props })
+  const stack = new TestStack(app, 'test-deep-merge-extra-stack', props)
+
+  test('overlay overrides nested logging.level from base', () => {
+    // base='error', overlay='warn', stage(test.json) has no serverConfig → overlay wins
+    expect(stack.props.serverConfig.logging.level).toEqual('warn')
+  })
+
+  test('base logging.format survives through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.logging.format).toEqual('json')
+  })
+
+  test('base logging.destination survives through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.logging.destination).toEqual('stdout')
+  })
+
+  test('base cache object survives entirely through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.cache).toEqual({
+      enabled: true,
+      ttl: 300,
+      maxSize: 1000,
+    })
+  })
+
+  test('overlay overrides monitoring.enabled from base', () => {
+    expect(stack.props.serverConfig.monitoring.enabled).toEqual(true)
+  })
+
+  test('base monitoring.endpoint survives through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.monitoring.endpoint).toEqual('https://monitor.example.com')
+  })
+})
+
+describe('CommonStack - Deep Merge - Region Context', () => {
+  const props = {
+    domainName: 'gradientedge.io',
+    extraContexts: [
+      'packages/aws/test/common/cdk-config/deep-merge-base.json',
+      'packages/aws/test/common/cdk-config/deep-merge-overlay.json',
+    ],
+    regionContextPath: 'packages/aws/test/common/cdk-region',
+    name: 'test-deep-merge-region',
+    region: 'deep-merge-eu-west-1',
+    stackName: 'test-deep-merge-region',
+    stage: 'test',
+    stageContextPath: 'packages/aws/test/common/cdk-env',
+  }
+
+  class TestStack extends CommonStack {
+    declare props: TestStackProps
+
+    constructor(parent: cdk.App, name: string, stackProps: any) {
+      super(parent, name, props)
+    }
+
+    protected determineConstructProps(stackProps: cdk.StackProps) {
+      return {
+        ...super.determineConstructProps(stackProps),
+        serverConfig: this.node.tryGetContext('serverConfig'),
+        logLevel: this.node.tryGetContext('logLevel'),
+      }
+    }
+  }
+
+  const app = new cdk.App({ context: props })
+  const stack = new TestStack(app, 'test-deep-merge-region-stack', props)
+
+  test('region overrides logging.level', () => {
+    // base='error', overlay='warn', region='info', stage(test.json) has no serverConfig → region wins
+    expect(stack.props.serverConfig.logging.level).toEqual('info')
+  })
+
+  test('region overrides logging.destination', () => {
+    expect(stack.props.serverConfig.logging.destination).toEqual('cloudwatch')
+  })
+
+  test('base logging.format survives through region (not set in region)', () => {
+    expect(stack.props.serverConfig.logging.format).toEqual('json')
+  })
+
+  test('region overrides cache.ttl, base cache.enabled and cache.maxSize survive', () => {
+    expect(stack.props.serverConfig.cache.ttl).toEqual(600)
+    expect(stack.props.serverConfig.cache.enabled).toEqual(true)
+    expect(stack.props.serverConfig.cache.maxSize).toEqual(1000)
+  })
+
+  test('region adds serverConfig.region, base monitoring survives', () => {
+    expect(stack.props.serverConfig.region).toEqual('eu-west-1')
+    expect(stack.props.serverConfig.monitoring.enabled).toEqual(true)
+    expect(stack.props.serverConfig.monitoring.endpoint).toEqual('https://monitor.example.com')
+  })
+})
+
+describe('CommonStack - Deep Merge - Full Hierarchy', () => {
+  const props = {
+    domainName: 'gradientedge.io',
+    extraContexts: [
+      'packages/aws/test/common/cdk-config/deep-merge-base.json',
+      'packages/aws/test/common/cdk-config/deep-merge-overlay.json',
+    ],
+    regionContextPath: 'packages/aws/test/common/cdk-region',
+    stageRegionContextPath: 'packages/aws/test/common/cdk-env-region',
+    name: 'test-deep-merge-full',
+    region: 'deep-merge-eu-west-1',
+    stackName: 'test-deep-merge-full',
+    stage: 'deep-merge-tst',
+    stageContextPath: 'packages/aws/test/common/cdk-env',
+  }
+
+  class TestStack extends CommonStack {
+    declare props: TestStackProps
+
+    constructor(parent: cdk.App, name: string, stackProps: any) {
+      super(parent, name, props)
+    }
+
+    protected determineConstructProps(stackProps: cdk.StackProps) {
+      return {
+        ...super.determineConstructProps(stackProps),
+        serverConfig: this.node.tryGetContext('serverConfig'),
+        logLevel: this.node.tryGetContext('logLevel'),
+      }
+    }
+  }
+
+  const app = new cdk.App({ context: props })
+  const stack = new TestStack(app, 'test-deep-merge-full-stack', props)
+
+  test('stage-region wins for logging.level (set in all 5 layers)', () => {
+    // base='error', overlay='warn', region='info', stage='debug', stage-region='trace'
+    expect(stack.props.serverConfig.logging.level).toEqual('trace')
+  })
+
+  test('base logging.format survives through all layers (only set in base)', () => {
+    expect(stack.props.serverConfig.logging.format).toEqual('json')
+  })
+
+  test('region logging.destination survives through stage and stage-region', () => {
+    // base='stdout', region='cloudwatch', not set in stage or stage-region
+    expect(stack.props.serverConfig.logging.destination).toEqual('cloudwatch')
+  })
+
+  test('stage overrides cache.maxSize, region overrides cache.ttl, base cache.enabled survives', () => {
+    // base: enabled=true, ttl=300, maxSize=1000
+    // region: ttl=600
+    // stage: maxSize=2000
+    expect(stack.props.serverConfig.cache.enabled).toEqual(true)
+    expect(stack.props.serverConfig.cache.ttl).toEqual(600)
+    expect(stack.props.serverConfig.cache.maxSize).toEqual(2000)
+  })
+
+  test('overlay monitoring.enabled survives through all higher layers', () => {
+    // base: enabled=false, overlay: enabled=true, not set in region/stage/stage-region
+    expect(stack.props.serverConfig.monitoring.enabled).toEqual(true)
+  })
+
+  test('base monitoring.endpoint survives through all layers', () => {
+    expect(stack.props.serverConfig.monitoring.endpoint).toEqual('https://monitor.example.com')
+  })
+
+  test('region serverConfig.region survives through stage and stage-region', () => {
+    expect(stack.props.serverConfig.region).toEqual('eu-west-1')
+  })
+
+  test('primitive props follow highest-priority-wins: stage-region logLevel wins', () => {
+    expect(stack.props.logLevel).toEqual('trace')
+  })
+
+  test('primitive props from intermediate layers survive when not overridden', () => {
+    // subDomain set only in stage, not overridden by stage-region
+    expect(stack.props.subDomain).toEqual('tst')
+  })
+
+  test('base globalPrefix survives all layers', () => {
+    expect(stack.props.globalPrefix).toEqual('gradientedge')
+  })
+})

--- a/packages/azure/src/common/stack.ts
+++ b/packages/azure/src/common/stack.ts
@@ -66,18 +66,21 @@ export class CommonAzureStack extends ComponentResource {
    * @returns The stack properties
    */
   protected determineConstructProps(props: CommonAzureStackProps) {
-    return {
-      ...props,
-      extraContexts: this.config.getObject('extraContexts'),
-      regionContextPath: this.config.get('regionContextPath'),
-      stage: this.config.get('stage'),
-      stageContextPath: this.config.get('stageContextPath'),
-      stageRegionContextPath: this.config.get('stageRegionContextPath'),
-      ...this.determineExtraContexts(),
-      ...this.determineRegionContexts(),
-      ...this.determineStageContexts(),
-      ...this.determineStageRegionContexts(),
-    }
+    return _.merge(
+      {},
+      props,
+      {
+        extraContexts: this.config.getObject('extraContexts'),
+        regionContextPath: this.config.get('regionContextPath'),
+        stage: this.config.get('stage'),
+        stageContextPath: this.config.get('stageContextPath'),
+        stageRegionContextPath: this.config.get('stageRegionContextPath'),
+      },
+      this.determineExtraContexts(),
+      this.determineRegionContexts(),
+      this.determineStageContexts(),
+      this.determineStageRegionContexts()
+    )
   }
 
   /**
@@ -106,10 +109,7 @@ export class CommonAzureStack extends ComponentResource {
       if (debug) console.debug(`Adding additional contexts provided in ${extraContextPath}`)
 
       /* parse as JSON properties */
-      extraContextProps = {
-        ...extraContextProps,
-        ...JSON.parse(extraContextPropsBuffer.toString('utf-8')),
-      }
+      extraContextProps = _.merge(extraContextProps, JSON.parse(extraContextPropsBuffer.toString('utf-8')))
     })
     return extraContextProps
   }

--- a/packages/azure/test/common/common-azure-stack-deep-merge.test.ts
+++ b/packages/azure/test/common/common-azure-stack-deep-merge.test.ts
@@ -1,0 +1,174 @@
+import * as pulumi from '@pulumi/pulumi'
+import { CommonAzureStack, CommonAzureStackProps } from '../../src/index.js'
+
+interface TestAzureStackProps extends CommonAzureStackProps {
+  serverConfig?: any
+  logLevel?: string
+}
+
+class TestAzureStack extends CommonAzureStack {
+  declare props: TestAzureStackProps
+
+  constructor(name: string, props: TestAzureStackProps) {
+    super(name, props)
+  }
+}
+
+pulumi.runtime.setMocks({
+  newResource: (args: pulumi.runtime.MockResourceArgs) => {
+    return {
+      id: `${args.name}-id`,
+      state: { ...args.inputs },
+    }
+  },
+  call: (args: pulumi.runtime.MockCallArgs) => {
+    return args.inputs
+  },
+})
+
+const baseContexts = [
+  'packages/azure/test/common/config/deep-merge-base.json',
+  'packages/azure/test/common/config/deep-merge-overlay.json',
+]
+
+describe('CommonAzureStack - Deep Merge - Extra Contexts', () => {
+  pulumi.runtime.setAllConfig({
+    'project:stage': 'nonexistent',
+    'project:stageContextPath': 'packages/azure/test/common/env',
+    'project:extraContexts': JSON.stringify(baseContexts),
+  })
+
+  const stack = new TestAzureStack('test-dm-extra', {
+    domainName: 'gradientedge.io',
+    name: 'test-dm-extra',
+    resourceGroupName: 'test-rg',
+    extraContexts: baseContexts,
+  } as any)
+
+  test('overlay overrides nested logging.level from base', () => {
+    expect(stack.props.serverConfig.logging.level).toEqual('warn')
+  })
+
+  test('base logging.format survives through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.logging.format).toEqual('json')
+  })
+
+  test('base logging.destination survives through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.logging.destination).toEqual('stdout')
+  })
+
+  test('base cache object survives entirely through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.cache).toEqual({
+      enabled: true,
+      ttl: 300,
+      maxSize: 1000,
+    })
+  })
+
+  test('overlay overrides monitoring.enabled from base', () => {
+    expect(stack.props.serverConfig.monitoring.enabled).toEqual(true)
+  })
+
+  test('base monitoring.endpoint survives through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.monitoring.endpoint).toEqual('https://monitor.example.com')
+  })
+})
+
+describe('CommonAzureStack - Deep Merge - Region Context', () => {
+  pulumi.runtime.setAllConfig({
+    'project:stage': 'nonexistent',
+    'project:stageContextPath': 'packages/azure/test/common/env',
+    'project:extraContexts': JSON.stringify(baseContexts),
+    'project:location': 'deep-merge-uksouth',
+    'project:regionContextPath': 'packages/azure/test/common/region',
+  })
+
+  const stack = new TestAzureStack('test-dm-region', {
+    domainName: 'gradientedge.io',
+    name: 'test-dm-region',
+    resourceGroupName: 'test-rg',
+    extraContexts: baseContexts,
+  } as any)
+
+  test('region overrides logging.destination from base', () => {
+    expect(stack.props.serverConfig.logging.destination).toEqual('azure-monitor')
+  })
+
+  test('base logging.format survives through region (not set in region)', () => {
+    expect(stack.props.serverConfig.logging.format).toEqual('json')
+  })
+
+  test('region overrides cache.ttl, base cache.enabled and cache.maxSize survive', () => {
+    expect(stack.props.serverConfig.cache.ttl).toEqual(600)
+    expect(stack.props.serverConfig.cache.enabled).toEqual(true)
+    expect(stack.props.serverConfig.cache.maxSize).toEqual(1000)
+  })
+
+  test('region adds serverConfig.region, monitoring from overlay survives', () => {
+    expect(stack.props.serverConfig.region).toEqual('uksouth')
+    expect(stack.props.serverConfig.monitoring.enabled).toEqual(true)
+    expect(stack.props.serverConfig.monitoring.endpoint).toEqual('https://monitor.example.com')
+  })
+})
+
+describe('CommonAzureStack - Deep Merge - Full Hierarchy', () => {
+  pulumi.runtime.setAllConfig({
+    'project:stage': 'deep-merge-tst',
+    'project:stageContextPath': 'packages/azure/test/common/env',
+    'project:extraContexts': JSON.stringify(baseContexts),
+    'project:location': 'deep-merge-uksouth',
+    'project:regionContextPath': 'packages/azure/test/common/region',
+    'project:stageRegionContextPath': 'packages/azure/test/common/env-region',
+  })
+
+  const stack = new TestAzureStack('test-dm-full', {
+    domainName: 'gradientedge.io',
+    name: 'test-dm-full',
+    resourceGroupName: 'test-rg',
+    extraContexts: baseContexts,
+  } as any)
+
+  test('stage-region wins for logging.level (set in all 5 layers)', () => {
+    // base='error', overlay='warn', region='info', stage='debug', stage-region='trace'
+    expect(stack.props.serverConfig.logging.level).toEqual('trace')
+  })
+
+  test('base logging.format survives through all layers (only set in base)', () => {
+    expect(stack.props.serverConfig.logging.format).toEqual('json')
+  })
+
+  test('region logging.destination survives through stage and stage-region', () => {
+    // base='stdout', region='azure-monitor', not set in stage or stage-region
+    expect(stack.props.serverConfig.logging.destination).toEqual('azure-monitor')
+  })
+
+  test('stage overrides cache.maxSize, region overrides cache.ttl, base cache.enabled survives', () => {
+    expect(stack.props.serverConfig.cache.enabled).toEqual(true)
+    expect(stack.props.serverConfig.cache.ttl).toEqual(600)
+    expect(stack.props.serverConfig.cache.maxSize).toEqual(2000)
+  })
+
+  test('overlay monitoring.enabled survives through all higher layers', () => {
+    expect(stack.props.serverConfig.monitoring.enabled).toEqual(true)
+  })
+
+  test('base monitoring.endpoint survives through all layers', () => {
+    expect(stack.props.serverConfig.monitoring.endpoint).toEqual('https://monitor.example.com')
+  })
+
+  test('region serverConfig.region survives through stage and stage-region', () => {
+    expect(stack.props.serverConfig.region).toEqual('uksouth')
+  })
+
+  test('primitive props follow highest-priority-wins: stage-region logLevel wins', () => {
+    expect(stack.props.logLevel).toEqual('trace')
+  })
+
+  test('primitive props from intermediate layers survive when not overridden', () => {
+    expect(stack.props.subDomain).toEqual('tst')
+  })
+
+  test('base globalPrefix survives all layers', () => {
+    expect(stack.props.globalPrefix).toEqual('gradientedge')
+  })
+})

--- a/packages/azure/test/common/config/deep-merge-base.json
+++ b/packages/azure/test/common/config/deep-merge-base.json
@@ -1,0 +1,21 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "error",
+      "format": "json",
+      "destination": "stdout"
+    },
+    "cache": {
+      "enabled": true,
+      "ttl": 300,
+      "maxSize": 1000
+    },
+    "monitoring": {
+      "enabled": false,
+      "endpoint": "https://monitor.example.com"
+    }
+  },
+  "logLevel": "error",
+  "resourcePrefix": "ge",
+  "globalPrefix": "gradientedge"
+}

--- a/packages/azure/test/common/config/deep-merge-overlay.json
+++ b/packages/azure/test/common/config/deep-merge-overlay.json
@@ -1,0 +1,10 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "warn"
+    },
+    "monitoring": {
+      "enabled": true
+    }
+  }
+}

--- a/packages/azure/test/common/env-region/deep-merge-tst.deep-merge-uksouth.json
+++ b/packages/azure/test/common/env-region/deep-merge-tst.deep-merge-uksouth.json
@@ -1,0 +1,9 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "trace"
+    }
+  },
+  "logLevel": "trace",
+  "resourcePrefix": "ge-tst-uksouth"
+}

--- a/packages/azure/test/common/env/deep-merge-tst.json
+++ b/packages/azure/test/common/env/deep-merge-tst.json
@@ -1,0 +1,14 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "debug"
+    },
+    "cache": {
+      "maxSize": 2000
+    }
+  },
+  "logLevel": "debug",
+  "resourcePrefix": "ge-tst",
+  "subDomain": "tst",
+  "stage": "deep-merge-tst"
+}

--- a/packages/azure/test/common/region/deep-merge-uksouth.json
+++ b/packages/azure/test/common/region/deep-merge-uksouth.json
@@ -1,0 +1,14 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "info",
+      "destination": "azure-monitor"
+    },
+    "cache": {
+      "ttl": 600
+    },
+    "region": "uksouth"
+  },
+  "logLevel": "warn",
+  "resourcePrefix": "ge-uksouth"
+}

--- a/packages/cloudflare/src/common/stack.ts
+++ b/packages/cloudflare/src/common/stack.ts
@@ -60,14 +60,17 @@ export class CommonCloudflareStack extends ComponentResource {
       projectProps = JSON.parse(projectPropsBuffer.toString('utf-8'))
     }
 
-    return {
-      ...props,
-      extraContexts: this.config.getObject('extraContexts'),
-      stage: this.config.get('stage'),
-      stageContextPath: this.config.get('stageContextPath'),
-      ...this.determineExtraContexts(),
-      ...this.determineStageContexts(),
-    }
+    return _.merge(
+      {},
+      props,
+      {
+        extraContexts: this.config.getObject('extraContexts'),
+        stage: this.config.get('stage'),
+        stageContextPath: this.config.get('stageContextPath'),
+      },
+      this.determineExtraContexts(),
+      this.determineStageContexts()
+    )
   }
 
   /**
@@ -96,10 +99,7 @@ export class CommonCloudflareStack extends ComponentResource {
       if (debug) console.debug(`Adding additional contexts provided in ${extraContextPath}`)
 
       /* parse as JSON properties */
-      extraContextProps = {
-        ...extraContextProps,
-        ...JSON.parse(extraContextPropsBuffer.toString('utf-8')),
-      }
+      extraContextProps = _.merge(extraContextProps, JSON.parse(extraContextPropsBuffer.toString('utf-8')))
     })
     return extraContextProps
   }

--- a/packages/cloudflare/test/common/common-cloudflare-stack-deep-merge.test.ts
+++ b/packages/cloudflare/test/common/common-cloudflare-stack-deep-merge.test.ts
@@ -1,0 +1,126 @@
+import * as pulumi from '@pulumi/pulumi'
+import { CommonCloudflareStack, CommonCloudflareStackProps } from '../../src/index.js'
+
+interface TestCloudflareStackProps extends CommonCloudflareStackProps {
+  serverConfig?: any
+  logLevel?: string
+  globalPrefix?: string
+}
+
+class TestCloudflareStack extends CommonCloudflareStack {
+  declare props: TestCloudflareStackProps
+
+  constructor(name: string, props: TestCloudflareStackProps) {
+    super(name, props)
+  }
+}
+
+const baseContexts = [
+  'packages/cloudflare/test/common/config/deep-merge-base.json',
+  'packages/cloudflare/test/common/config/deep-merge-overlay.json',
+]
+
+pulumi.runtime.setAllConfig({
+  'project:stage': 'nonexistent',
+  'project:stageContextPath': 'packages/cloudflare/test/common/env',
+  'project:extraContexts': JSON.stringify(baseContexts),
+})
+
+pulumi.runtime.setMocks({
+  newResource: (args: pulumi.runtime.MockResourceArgs) => {
+    return {
+      id: `${args.name}-id`,
+      state: { ...args.inputs },
+    }
+  },
+  call: (args: pulumi.runtime.MockCallArgs) => {
+    return args.inputs
+  },
+})
+
+describe('CommonCloudflareStack - Deep Merge - Extra Contexts', () => {
+  const stack = new TestCloudflareStack('test-dm-extra', {
+    accountId: '123456789012',
+    domainName: 'gradientedge.io',
+    name: 'test-dm-extra',
+    extraContexts: baseContexts,
+  } as any)
+
+  test('overlay overrides nested logging.level from base', () => {
+    expect(stack.props.serverConfig.logging.level).toEqual('warn')
+  })
+
+  test('base logging.format survives through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.logging.format).toEqual('json')
+  })
+
+  test('base logging.destination survives through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.logging.destination).toEqual('stdout')
+  })
+
+  test('base cache object survives entirely through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.cache).toEqual({
+      enabled: true,
+      ttl: 300,
+      maxSize: 1000,
+    })
+  })
+
+  test('overlay overrides monitoring.enabled from base', () => {
+    expect(stack.props.serverConfig.monitoring.enabled).toEqual(true)
+  })
+
+  test('base monitoring.endpoint survives through overlay (not set in overlay)', () => {
+    expect(stack.props.serverConfig.monitoring.endpoint).toEqual('https://monitor.example.com')
+  })
+})
+
+describe('CommonCloudflareStack - Deep Merge - Stage Context', () => {
+  pulumi.runtime.setAllConfig({
+    'project:stage': 'deep-merge-tst',
+    'project:stageContextPath': 'packages/cloudflare/test/common/env',
+    'project:extraContexts': JSON.stringify(baseContexts),
+  })
+
+  const stack = new TestCloudflareStack('test-dm-stage', {
+    accountId: '123456789012',
+    domainName: 'gradientedge.io',
+    name: 'test-dm-stage',
+    extraContexts: baseContexts,
+  } as any)
+
+  test('stage overrides logging.level (base=error, overlay=warn, stage=debug)', () => {
+    expect(stack.props.serverConfig.logging.level).toEqual('debug')
+  })
+
+  test('base logging.format survives through overlay and stage (only set in base)', () => {
+    expect(stack.props.serverConfig.logging.format).toEqual('json')
+  })
+
+  test('base logging.destination survives through overlay and stage', () => {
+    expect(stack.props.serverConfig.logging.destination).toEqual('stdout')
+  })
+
+  test('stage overrides cache.maxSize, base cache.enabled and cache.ttl survive', () => {
+    expect(stack.props.serverConfig.cache.enabled).toEqual(true)
+    expect(stack.props.serverConfig.cache.ttl).toEqual(300)
+    expect(stack.props.serverConfig.cache.maxSize).toEqual(2000)
+  })
+
+  test('overlay monitoring.enabled survives through stage', () => {
+    expect(stack.props.serverConfig.monitoring.enabled).toEqual(true)
+  })
+
+  test('base monitoring.endpoint survives through overlay and stage', () => {
+    expect(stack.props.serverConfig.monitoring.endpoint).toEqual('https://monitor.example.com')
+  })
+
+  test('primitive props from stage override lower layers', () => {
+    expect(stack.props.logLevel).toEqual('debug')
+    expect(stack.props.subDomain).toEqual('tst')
+  })
+
+  test('base globalPrefix survives through overlay and stage', () => {
+    expect(stack.props.globalPrefix).toEqual('gradientedge')
+  })
+})

--- a/packages/cloudflare/test/common/config/deep-merge-base.json
+++ b/packages/cloudflare/test/common/config/deep-merge-base.json
@@ -1,0 +1,21 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "error",
+      "format": "json",
+      "destination": "stdout"
+    },
+    "cache": {
+      "enabled": true,
+      "ttl": 300,
+      "maxSize": 1000
+    },
+    "monitoring": {
+      "enabled": false,
+      "endpoint": "https://monitor.example.com"
+    }
+  },
+  "logLevel": "error",
+  "resourcePrefix": "ge",
+  "globalPrefix": "gradientedge"
+}

--- a/packages/cloudflare/test/common/config/deep-merge-overlay.json
+++ b/packages/cloudflare/test/common/config/deep-merge-overlay.json
@@ -1,0 +1,10 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "warn"
+    },
+    "monitoring": {
+      "enabled": true
+    }
+  }
+}

--- a/packages/cloudflare/test/common/env/deep-merge-tst.json
+++ b/packages/cloudflare/test/common/env/deep-merge-tst.json
@@ -1,0 +1,14 @@
+{
+  "serverConfig": {
+    "logging": {
+      "level": "debug"
+    },
+    "cache": {
+      "maxSize": 2000
+    }
+  },
+  "logLevel": "debug",
+  "resourcePrefix": "ge-tst",
+  "subDomain": "tst",
+  "stage": "deep-merge-tst"
+}


### PR DESCRIPTION
## Summary
  - Replace shallow spread/setContext merging with `_.merge` for config hierarchy props across AWS, Azure, and Cloudflare stacks
  - Ensures nested object properties from lower-priority layers survive when higher-priority layers only override specific sub-properties
  - Previously, a stage-region config overriding one field in a nested object (e.g., `testLambda.memorySize`) would silently discard all other fields set by lower layers (e.g., `testLambda.tags` from the region
  layer)