### PR TITLE
feat: auto-include umbrella package in changesets

### DIFF
--- a/.changeset/empty-nails-sniff.md
+++ b/.changeset/empty-nails-sniff.md
@@ -1,0 +1,9 @@
+---
+'@gradientedge/cdk-utils-aws': minor
+'@gradientedge/cdk-utils-azure': minor
+'@gradientedge/cdk-utils-cloudflare': minor
+'@gradientedge/cdk-utils-common': minor
+'@gradientedge/cdk-utils': minor
+---
+
+feat: bumping versions

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 pnpm prettify && pnpm validate
+bash scripts/ensure-umbrella-changeset.sh

--- a/scripts/ensure-umbrella-changeset.sh
+++ b/scripts/ensure-umbrella-changeset.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Ensures @gradientedge/cdk-utils (umbrella) is included in every changeset
+# that bumps a sub-package. Uses the highest bump level found.
+
+set -euo pipefail
+
+UMBRELLA="@gradientedge/cdk-utils"
+
+# Find staged changeset markdown files (excluding README and config)
+changeset_files=$(git diff --cached --name-only --diff-filter=ACM -- '.changeset/*.md' | grep -v README || true)
+
+if [ -z "$changeset_files" ]; then
+  exit 0
+fi
+
+for file in $changeset_files; do
+  # Skip if umbrella is already listed (match exact name, not sub-packages like cdk-utils-aws)
+  if grep -qE "(@gradientedge/cdk-utils)['\"]:" "$file"; then
+    continue
+  fi
+
+  # Extract the frontmatter (between --- markers)
+  frontmatter=$(sed -n '/^---$/,/^---$/p' "$file")
+
+  # Find the highest bump level in the changeset
+  highest=""
+  if echo "$frontmatter" | grep -q ": major"; then
+    highest="major"
+  elif echo "$frontmatter" | grep -q ": minor"; then
+    highest="minor"
+  elif echo "$frontmatter" | grep -q ": patch"; then
+    highest="patch"
+  fi
+
+  if [ -z "$highest" ]; then
+    continue
+  fi
+
+  # Insert the umbrella package line before the closing ---
+  awk -v pkg="$UMBRELLA" -v level="$highest" '
+    BEGIN { count = 0 }
+    /^---$/ {
+      count++
+      if (count == 2) {
+        print "'\''" pkg "'\'': " level
+      }
+    }
+    { print }
+  ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+
+  echo "Auto-added $UMBRELLA ($highest) to $file"
+
+  # Re-stage the modified file
+  git add "$file"
+done


### PR DESCRIPTION
Summary
  - Adds a pre-commit hook script that automatically injects @gradientedge/cdk-utils into any changeset that bumps a sub-package, using the highest bump level found
  - No manual effort needed. the umbrella package version stays in sync with sub-package releases