### PR TITLE
feat: Add support for tagsToIgnore

### DIFF
--- a/packages/azure/src/common/stack.ts
+++ b/packages/azure/src/common/stack.ts
@@ -53,7 +53,7 @@ export class CommonAzureStack extends ComponentResource {
 
     /* register tag transformation for automatic tag application */
     if (this.props.defaultTags) {
-      registerTagTransformation(this.props.defaultTags)
+      registerTagTransformation(this.props.defaultTags, this.props.tagsToIgnore ?? [])
     }
 
     this.createConstruct()

--- a/packages/azure/src/common/types.ts
+++ b/packages/azure/src/common/types.ts
@@ -51,6 +51,8 @@ export interface CommonAzureStackProps extends BaseProps {
   locales?: string[]
   /** Default tags applied to all taggable Azure resources */
   defaultTags?: { [key: string]: string }
+  /** Tag keys to ignore in Pulumi lifecycle management (e.g. tags set externally like 'CreatedOn') */
+  tagsToIgnore?: string[]
   /** Shared Log Analytics Workspace lookup arguments for diagnostic logging */
   commonLogAnalyticsWorkspace?: GetWorkspaceOutputArgs
   /** Shared Application Insights component lookup arguments for telemetry */

--- a/packages/azure/test/common/common-azure-stack.test.ts
+++ b/packages/azure/test/common/common-azure-stack.test.ts
@@ -336,4 +336,21 @@ describe('TestAzureCommonStack - defaultTags', () => {
     expect(stack.props).toBeDefined()
     expect(stack.props.defaultTags).toBeUndefined()
   })
+
+  test('tagsToIgnore is stored on props when provided', () => {
+    const stack = new TestAzureStack('test-stack-tags-to-ignore', {
+      ...testStackProps,
+      defaultTags: undefined,
+      tagsToIgnore: ['CreatedOn', 'CreatedAt'],
+    })
+    expect(stack.props.tagsToIgnore).toEqual(['CreatedOn', 'CreatedAt'])
+  })
+
+  test('tagsToIgnore defaults to undefined when not provided', () => {
+    const stack = new TestAzureStack('test-stack-no-tags-to-ignore', {
+      ...testStackProps,
+      defaultTags: undefined,
+    })
+    expect(stack.props.tagsToIgnore).toBeUndefined()
+  })
 })


### PR DESCRIPTION
This pull request adds support for specifying tag keys to ignore during Pulumi lifecycle management in the Azure stack, allowing users to exclude certain tags (e.g., those set externally) from automatic tag application. The changes include updates to the stack props, stack initialization logic, and new tests for this functionality.

**Support for ignoring tags during resource management:**

* Added a new `tagsToIgnore` property to the `CommonAzureStackProps` interface, allowing users to specify tag keys to be ignored by Pulumi when managing Azure resources.
* Updated the `CommonAzureStack` constructor to pass the `tagsToIgnore` array (or an empty array if not provided) to the `registerTagTransformation` function, ensuring ignored tags are respected during tag application.

**Testing enhancements:**

* Added tests to verify that `tagsToIgnore` is stored on the stack props when provided, and defaults to `undefined` when not set.