### PR TITLE
feat(lambda): optional version-pinned provisioned concurrency

### DIFF
--- a/.changeset/lambda-pc-on-version.md
+++ b/.changeset/lambda-pc-on-version.md
@@ -1,0 +1,10 @@
+---
+'@gradientedge/cdk-utils-aws': minor
+'@gradientedge/cdk-utils': minor
+---
+
+Add `ProvisionedConcurrencyProps.onVersion` flag. When `true`, provisioned concurrency and its auto-scaling target attach to the published function version (`function:<fn>:<version>`) instead of the alias (`function:<fn>:<aliasName>`).
+
+This avoids a deploy-wedging trap: when PC is on the alias, every CFN alias update that changes `FunctionVersion` triggers Lambda's built-in canary behaviour (CFN sets `RoutingConfig.AdditionalVersionWeights` to keep traffic on the old version until PC allocates on the new one). If the new version's init fails (`FUNCTION_ERROR_INIT_FAILURE`), the routing weights persist at 100% on old and every subsequent deploy fails with `Invalid alias configuration for Provisioned Concurrency`. With PC on the version instead, alias updates are atomic, no routing weights are ever set, and the wedge can't happen.
+
+Default is `false`; existing consumers are unaffected. Trade-off: ApplicationAutoScaling targets accumulate one per deploy (resource id embeds the version) — fine for normal cadence; regional soft limit is 2,500.

--- a/packages/aws/src/services/lambda/main.ts
+++ b/packages/aws/src/services/lambda/main.ts
@@ -7,6 +7,7 @@ import {
   Alias,
   Architecture,
   AssetCode,
+  CfnVersion,
   DockerImageCode,
   DockerImageFunction,
   FileSystem,
@@ -15,6 +16,7 @@ import {
   IVersion,
   LayerVersion,
 } from 'aws-cdk-lib/aws-lambda'
+import { PredefinedMetric, ScalableTarget, ServiceNamespace } from 'aws-cdk-lib/aws-applicationautoscaling'
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources'
 import _ from 'lodash'
 
@@ -190,10 +192,22 @@ export class LambdaManager {
         createCfnOutput(`${id}-${alias.aliasName}AliasName`, scope, functionAlias.aliasName)
 
         if (alias.provisionedConcurrency) {
-          const functionAutoScaling = functionAlias.addAutoScaling(alias.provisionedConcurrency)
-          functionAutoScaling.scaleOnUtilization({
-            utilizationTarget: alias.provisionedConcurrency.utilizationTarget,
-          })
+          if (alias.provisionedConcurrency.onVersion) {
+            /* Attach PC + autoscaling to the published function VERSION rather
+               than the alias. See ProvisionedConcurrencyProps.onVersion docs
+               for the deploy-failure trap this exists to avoid. */
+            this.attachProvisionedConcurrencyToVersion(
+              `${aliasId}-pc`,
+              scope,
+              lambdaFunction,
+              alias.provisionedConcurrency
+            )
+          } else {
+            const functionAutoScaling = functionAlias.addAutoScaling(alias.provisionedConcurrency)
+            functionAutoScaling.scaleOnUtilization({
+              utilizationTarget: alias.provisionedConcurrency.utilizationTarget,
+            })
+          }
         }
       })
       lambdaFunction.lambdaAliases = aliasMap
@@ -344,6 +358,51 @@ export class LambdaManager {
    * @param props the Lambda alias properties
    * @param lambdaVersion the Lambda function version to point the alias to
    */
+  /**
+   * @summary Attach provisioned concurrency + an autoscaling target to a Lambda
+   * version (resource id `function:<fn>:<version>`) rather than an alias. The
+   * version is warmed before the alias swap, and the alias itself carries no
+   * PC config — so CFN alias updates remain atomic and never trip the
+   * `Invalid alias configuration for Provisioned Concurrency` deploy failure
+   * mode documented on {@link ProvisionedConcurrencyProps.onVersion}.
+   * @param id scoped id prefix for the PC + scaling resources
+   * @param scope scope the resources are added to
+   * @param lambdaFunction the function whose currentVersion to attach PC to
+   * @param props the PC + autoscaling props
+   */
+  protected attachProvisionedConcurrencyToVersion(
+    id: string,
+    scope: CommonConstruct,
+    lambdaFunction: Function,
+    props: { maxCapacity: number; minCapacity: number; utilizationTarget: number }
+  ) {
+    const version = lambdaFunction.currentVersion
+
+    /* CDK doesn't expose AWS::Lambda::ProvisionedConcurrencyConfig as a
+       standalone L1 — set PC inline on the published CfnVersion instead.
+       Same CFN-level effect: PC attaches to the version, not the alias. */
+    const cfnVersion = version.node.defaultChild as CfnVersion
+    cfnVersion.provisionedConcurrencyConfig = {
+      provisionedConcurrentExecutions: props.minCapacity,
+    }
+
+    const scalableTarget = new ScalableTarget(scope, `${id}-target`, {
+      serviceNamespace: ServiceNamespace.LAMBDA,
+      resourceId: `function:${lambdaFunction.functionName}:${version.version}`,
+      scalableDimension: 'lambda:function:ProvisionedConcurrency',
+      minCapacity: props.minCapacity,
+      maxCapacity: props.maxCapacity,
+    })
+    scalableTarget.node.addDependency(version)
+
+    scalableTarget.scaleToTrackMetric(`${id}-utilization`, {
+      targetValue: props.utilizationTarget,
+      predefinedMetric: PredefinedMetric.LAMBDA_PROVISIONED_CONCURRENCY_UTILIZATION,
+    })
+
+    return scalableTarget
+  }
+
   public createLambdaFunctionAlias(
     id: string,
     scope: CommonConstruct,

--- a/packages/aws/src/services/lambda/types.ts
+++ b/packages/aws/src/services/lambda/types.ts
@@ -29,7 +29,8 @@ export interface EdgeFunctionProps extends FunctionProps {
 }
 
 /**
- * Properties for configuring provisioned concurrency auto-scaling on a Lambda alias.
+ * Properties for configuring provisioned concurrency auto-scaling on a Lambda alias
+ * or on the function's published version.
  */
 /** @category Interface */
 export interface ProvisionedConcurrencyProps {
@@ -39,6 +40,35 @@ export interface ProvisionedConcurrencyProps {
   minCapacity: number
   /** Target utilization percentage to trigger scaling (0-1) */
   utilizationTarget: number
+  /**
+   * When true, attach provisioned concurrency (and its auto-scaling target)
+   * to the function's published version (`function:<fn>:<version>`) instead
+   * of the alias (`function:<fn>:<aliasName>`).
+   *
+   * Why this exists: when PC is on the alias, every CFN alias update that
+   * changes `FunctionVersion` triggers Lambda's built-in canary deploy
+   * behaviour — CFN sets `RoutingConfig.AdditionalVersionWeights` to keep
+   * traffic on the old version until PC is allocated on the new one. If
+   * the new version's init fails (`FUNCTION_ERROR_INIT_FAILURE`), the
+   * routing weights persist at 100% on old and **every subsequent deploy
+   * fails** with `Invalid alias configuration for Provisioned Concurrency`
+   * because Lambda forbids PC + routing config on the same alias update.
+   *
+   * Attaching PC to the version sidesteps this: the alias has no PC, so
+   * version swaps are atomic and never set routing weights. The new
+   * version is warmed by PC before the alias points at it because CDK
+   * publishes a new `currentVersion` on every change and the PC config /
+   * autoscaling target attach to that version explicitly.
+   *
+   * Trade-off: ApplicationAutoScaling targets accumulate one per deploy
+   * (since the resource ID embeds the version number). Combine with
+   * `RemovalPolicy.DESTROY` on the underlying scaling resources if your
+   * stack is updated frequently; the keep-targets-around limit is 2,500
+   * per region per account.
+   *
+   * @default false (PC stays on the alias — legacy behaviour)
+   */
+  onVersion?: boolean
 }
 
 /**

--- a/packages/aws/test/common/cdk-config/lambdas.json
+++ b/packages/aws/test/common/cdk-config/lambdas.json
@@ -71,6 +71,24 @@
     ],
     "timeoutInSecs": 60
   },
+  "testLambdaWithVersionPinnedConcurrency": {
+    "functionName": "test-lambda-version-pc",
+    "logRetentionInDays": 7,
+    "memorySize": 1024,
+    "lambdaAliases": [
+      {
+        "aliasName": "test-version-pc-alias",
+        "retryAttempts": 0,
+        "provisionedConcurrency": {
+          "minCapacity": 1,
+          "maxCapacity": 3,
+          "utilizationTarget": 0.7,
+          "onVersion": true
+        }
+      }
+    ],
+    "timeoutInSecs": 60
+  },
   "testLambdaWithDlq": {
     "functionName": "test-lambda-with-error-handling",
     "logRetentionInDays": 7,

--- a/packages/aws/test/services/lambda-manager.test.ts
+++ b/packages/aws/test/services/lambda-manager.test.ts
@@ -13,6 +13,7 @@ interface TestStackProps extends CommonStackProps {
   testLambdaEdge: any
   testLambdaPython: any
   testLambdaWithConcurrency: any
+  testLambdaWithVersionPinnedConcurrency: any
   testLambdaWithDlq: any
   testLambdaWithDlqRetries: any
   testDockerLambdaWithDlqRetries: any
@@ -51,6 +52,7 @@ class TestCommonStack extends CommonStack {
         testLambdaEdge: this.node.tryGetContext('testLambdaEdge'),
         testLambdaPython: this.node.tryGetContext('testLambdaPython'),
         testLambdaWithConcurrency: this.node.tryGetContext('testLambdaWithConcurrency'),
+        testLambdaWithVersionPinnedConcurrency: this.node.tryGetContext('testLambdaWithVersionPinnedConcurrency'),
         testLambdaWithDlq: this.node.tryGetContext('testLambdaWithDlq'),
         testLambdaWithDlqRetries: this.node.tryGetContext('testLambdaWithDlqRetries'),
         testDockerLambdaWithDlqRetries: this.node.tryGetContext('testDockerLambdaWithDlqRetries'),
@@ -105,6 +107,15 @@ class TestCommonConstruct extends CommonConstruct {
       'test-lambda-with-concurrency',
       this,
       this.props.testLambdaWithConcurrency,
+      testRole,
+      [testLayer],
+      new lambda.AssetCode('packages/aws/test/common/nodejs/lib')
+    )
+
+    this.lambdaManager.createLambdaFunction(
+      'test-lambda-with-version-pc',
+      this,
+      this.props.testLambdaWithVersionPinnedConcurrency,
       testRole,
       [testLayer],
       new lambda.AssetCode('packages/aws/test/common/nodejs/lib')
@@ -170,9 +181,9 @@ describe('TestLambdaConstruct', () => {
   test('synthesises as expected', () => {
     /* test if number of resources are correctly synthesised */
     template.resourceCountIs('AWS::Lambda::LayerVersion', 1)
-    template.resourceCountIs('AWS::Lambda::Function', 7)
+    template.resourceCountIs('AWS::Lambda::Function', 8)
     template.resourceCountIs('AWS::SQS::Queue', 6)
-    template.resourceCountIs('AWS::Lambda::Alias', 2)
+    template.resourceCountIs('AWS::Lambda::Alias', 3)
     template.resourceCountIs('AWS::Lambda::EventSourceMapping', 2)
   })
 })
@@ -520,5 +531,54 @@ describe('TestLambdaConstructErrorHandling', () => {
 
     const error = () => new TestErrorAliasStack(app, 'test-error-stack-alias', testStackProps)
     expect(error).toThrow('Lambda Alias props undefined')
+  })
+})
+
+describe('TestLambdaConstruct version-pinned provisioned concurrency', () => {
+  test('attaches ProvisionedConcurrencyConfig inline on the published Version', () => {
+    /* Version-pc lambda's published CfnVersion carries the PC config. */
+    template.hasResourceProperties('AWS::Lambda::Version', {
+      ProvisionedConcurrencyConfig: { ProvisionedConcurrentExecutions: 1 },
+    })
+  })
+
+  test('leaves the alias PC-free so CFN can update FunctionVersion atomically', () => {
+    /* The alias for the version-pc lambda must NOT carry ProvisionedConcurrencyConfig.
+       That's the whole point: alias updates are atomic, no routing weights get
+       set during deploy, and the deploy can never wedge on
+       "Invalid alias configuration for Provisioned Concurrency". */
+    const aliases = template.findResources('AWS::Lambda::Alias', {
+      Properties: { Name: 'test-version-pc-alias' },
+    })
+    const aliasResources = Object.values(aliases)
+    expect(aliasResources).toHaveLength(1)
+    expect(
+      (aliasResources[0] as { Properties: { ProvisionedConcurrencyConfig?: unknown } }).Properties
+        .ProvisionedConcurrencyConfig
+    ).toBeUndefined()
+  })
+
+  test('creates an ApplicationAutoScaling target against function:<fn>:<version>', () => {
+    /* Resource ID is built via Fn::Join with a Fn::GetAtt to the version's
+       Version attribute — that's what makes the target version-scoped. */
+    const targets = template.findResources('AWS::ApplicationAutoScaling::ScalableTarget')
+    const versionTarget = Object.values(targets).find(t => {
+      const resourceId = (t as { Properties?: { ResourceId?: unknown } }).Properties?.ResourceId
+      return JSON.stringify(resourceId).includes('CurrentVersion') && JSON.stringify(resourceId).includes('"Version"')
+    })
+    expect(versionTarget).toBeDefined()
+    const props = (versionTarget as { Properties: { MinCapacity: number; MaxCapacity: number } }).Properties
+    expect(props.MinCapacity).toBe(1)
+    expect(props.MaxCapacity).toBe(3)
+  })
+
+  test('uses LambdaProvisionedConcurrencyUtilization as the predefined target-tracking metric', () => {
+    template.hasResourceProperties('AWS::ApplicationAutoScaling::ScalingPolicy', {
+      PolicyType: 'TargetTrackingScaling',
+      TargetTrackingScalingPolicyConfiguration: {
+        PredefinedMetricSpecification: { PredefinedMetricType: 'LambdaProvisionedConcurrencyUtilization' },
+        TargetValue: 0.7,
+      },
+    })
   })
 })


### PR DESCRIPTION
## Why

When provisioned concurrency is attached to a Lambda **alias**, every CloudFormation alias update that changes `FunctionVersion` triggers Lambda's built-in canary deploy behaviour — CFN sets `RoutingConfig.AdditionalVersionWeights` to keep traffic on the old version until PC allocates on the new one. If the new version's init fails (`FUNCTION_ERROR_INIT_FAILURE`), those routing weights persist at 100% on old, and **every subsequent deploy fails** with:

```
Resource handler returned message: "Invalid alias configuration for
Provisioned Concurrency (Service: Lambda, Status Code: 400)"
```

because Lambda forbids `RoutingConfig` and `ProvisionedConcurrencyConfig` on the same alias update. The stack ends up wedged until an operator manually runs `aws lambda update-alias --routing-config '{}'`.

We hit this on `keystone-storefront`: a layer-shrink dropped `fast-safe-stringify` from the Next standalone bundle, v85 failed init, alias canary pinned to v84, and v86/v87 both failed with the same alias error even after fixing the bundle. Required manual alias clearing on five lambdas across two deploys to unstick.

## What

Add `onVersion?: boolean` to `ProvisionedConcurrencyProps` (default `false`). When `true`:

- PC attaches inline on the published `CfnVersion` (no standalone `AWS::Lambda::ProvisionedConcurrencyConfig` L1 exists in CDK).
- An `AWS::ApplicationAutoScaling::ScalableTarget` is created with `ResourceId: function:<fn>:<version>` and a target-tracking policy using `PredefinedMetric.LAMBDA_PROVISIONED_CONCURRENCY_UTILIZATION`.
- **The alias carries no PC config** — so CFN alias updates are atomic, never set routing weights, and the wedge can't happen.

```typescript
lambdaAliases: [{
  aliasName: 'latest',
  provisionedConcurrency: {
    minCapacity: 1,
    maxCapacity: 2,
    utilizationTarget: 0.8,
    onVersion: true,   // <-- attach PC to the version, not the alias
  },
}]
```

## Trade-off

The autoscaling target's `ResourceId` embeds the version number, so one target accumulates per deploy. Regional soft limit is **2,500 scalable targets** per region per account — fine for normal cadence; worth watching for runaway-rebuild scenarios.

## Backwards compatibility

Default is `false`. Existing consumers that don't set `onVersion` keep alias-based PC behaviour exactly as before.